### PR TITLE
Fix seeded results= values in both executors

### DIFF
--- a/asyncinject/__init__.py
+++ b/asyncinject/__init__.py
@@ -112,21 +112,32 @@ class Registry:
         return aw
 
     async def _execute_sequential(self, results, ts):
+        # Values seeded in results take precedence over registered functions
+        seeded = set(results.keys())
         for name in ts.static_order():
-            if name not in self._registry:
+            if name in seeded or name not in self._registry:
                 continue
             results[name] = await self._get_awaitable(name, results)
 
     async def _execute_parallel(self, results, ts):
         ts.prepare()
         tasks = []
+        # Values seeded in results take precedence over registered functions
+        seeded = set(results.keys())
 
         def schedule():
-            for name in ts.get_ready():
-                if name not in self._registry:
-                    ts.done(name)
-                    continue
-                tasks.append(asyncio.create_task(worker(name)))
+            # Marking a node done can make new nodes ready, so keep asking
+            # for ready nodes until there are none left - get_ready() never
+            # returns the same node twice so this always terminates
+            while True:
+                ready = ts.get_ready()
+                if not ready:
+                    break
+                for name in ready:
+                    if name in seeded or name not in self._registry:
+                        ts.done(name)
+                    else:
+                        tasks.append(asyncio.create_task(worker(name)))
 
         async def worker(name):
             res = await self._get_awaitable(name, results)

--- a/tests/test_asyncinject.py
+++ b/tests/test_asyncinject.py
@@ -251,3 +251,37 @@ async def test_registry_from_dict(use_string_name):
     else:
         result = await registry.resolve(_three)
     assert result == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parallel", (True, False))
+async def test_resolve_with_only_seeded_dependencies(parallel):
+    # The parallel executor used to stall when every initially-ready
+    # node was an unregistered value seeded via results=
+    async def b(a):
+        return a + 1
+
+    registry = Registry(b, parallel=parallel)
+    result = await registry.resolve(b, a=1)
+    assert result == 2
+
+    results = await registry.resolve_multi(["b"], results={"a": 5})
+    assert results["b"] == 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("parallel", (True, False))
+async def test_seeded_results_override_registered_functions(parallel):
+    calls = []
+
+    async def expensive():
+        calls.append("expensive")
+        return 5
+
+    async def consumer(expensive):
+        return expensive + 1
+
+    registry = Registry(expensive, consumer, parallel=parallel)
+    results = await registry.resolve_multi(["consumer"], results={"expensive": 10})
+    assert results["consumer"] == 11
+    assert calls == []


### PR DESCRIPTION
Two bugs with values pre-seeded via resolve_multi(results=...) / resolve(fn, **kwargs):

- The parallel executor stalled completely when every initially-ready node was an unregistered seeded value: schedule() iterated a single get_ready() snapshot, so marking those nodes done never triggered a re-scan and no tasks were ever created.
- Both executors re-computed registered functions even when a value for them had been seeded, so seeded values could not override registered dependencies.

schedule() now drains get_ready() until empty, and both executors skip names that were seeded before execution started.

Closes #19